### PR TITLE
Avoid duplicating toolbar btn

### DIFF
--- a/src/quill.htmlEditButton.js
+++ b/src/quill.htmlEditButton.js
@@ -1,7 +1,7 @@
 class htmlEditButton {
   constructor(quill, options) {
     // Add button to all quill toolbar instances
-    document.querySelectorAll(".ql-toolbar").forEach(toolbarEl => {
+    quill.container.parentElement.querySelectorAll(".ql-toolbar").forEach(toolbarEl => {
       const buttonContainer = document.createElement("span");
       buttonContainer.setAttribute("class", "ql-formats");
       const button = document.createElement("button");


### PR DESCRIPTION
Avoid duplicating toolbar btn on multiple quill instances
`document.querySelectorAll(".ql-toolbar")` selects all elements on the page. So if we try to add multiple instances of editors, we get HTML button duplication on each of the editors.

![image](https://user-images.githubusercontent.com/12899080/69333010-e9fc9c80-0c68-11ea-9677-eb84aad9c6db.png)
