### PR TITLE
feat(Syntax): add syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ modules: {
     okText: "Ok", // Text to display in the OK button, default: Ok,
     cancelText: "Cancel", // Text to display in the cancel button, default: Cancel
     buttonHTML: "&lt;&gt;", // Text to display in the toolbar button, default: <>
-    buttonTitle: "Show HTML source" // Text to display as the tooltip for the toolbar button, default: Show HTML source
+    buttonTitle: "Show HTML source", // Text to display as the tooltip for the toolbar button, default: Show HTML source
+    syntax: false // Show the HTML with syntax highlighting. Requires highlightjs on window.hljs (similar to Quill itself), default: false
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -6,33 +6,34 @@
   "repository": "https://github.com/benwinding/quill-html-edit-button",
   "author": "Ben Winding <ben.winding@gmail.com>",
   "license": "MIT",
-	"scripts": {
-		"watch": "webpack --watch --progress",
-		"start": "webpack-dev-server --mode development --hot --port 8001",
-		"build": "webpack --mode production"
-	},
-	"keywords": [
-		"quill",
-		"quilljs",
-		"html",
-		"button",
-		"edit"
-	],
-	"devDependencies": {
+  "scripts": {
+    "watch": "webpack --watch --progress",
+    "start": "webpack-dev-server --mode development --hot --port 8001",
+    "build": "webpack --mode production"
+  },
+  "keywords": [
+    "quill",
+    "quilljs",
+    "html",
+    "button",
+    "edit"
+  ],
+  "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.3",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
-		"babel-preset-env": "^1.6.1",
-		"css-loader": "^0.28.8",
-		"extract-text-webpack-plugin": "^4.0.0-beta.0",
-		"style-loader": "^0.19.1",
-		"uglifyjs-webpack-plugin": "^1.1.6",
-		"webpack": "^4.1.0",
-		"webpack-cli": "^3.2.1",
-		"webpack-dev-server": "^3.1.14"
-	},
-	"dependencies": {
-		"quill": "^1.x"
-	}
+    "babel-preset-env": "^1.6.1",
+    "css-loader": "^0.28.8",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
+    "highlight.js": "^10.1.2",
+    "style-loader": "^0.19.1",
+    "uglifyjs-webpack-plugin": "^1.1.6",
+    "webpack": "^4.1.0",
+    "webpack-cli": "^3.2.1",
+    "webpack-dev-server": "^3.1.14"
+  },
+  "dependencies": {
+    "quill": "^1.x"
+  }
 }

--- a/src/demo-script-tag.html
+++ b/src/demo-script-tag.html
@@ -11,6 +11,15 @@
       href="https://cdn.quilljs.com/1.3.6/quill.snow.css"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/styles/github.min.css"
+    />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/highlight.min.js"></script>
+    <script
+      charset="UTF-8"
+      src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/languages/xml.min.js"
+    ></script>
     <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
   </head>
 

--- a/src/demo.html
+++ b/src/demo.html
@@ -11,6 +11,15 @@
 			href="https://cdn.quilljs.com/1.3.6/quill.snow.css"
 			rel="stylesheet"
 		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/styles/github.min.css"
+		/>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/highlight.min.js"></script>
+		<script
+			charset="UTF-8"
+			src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/languages/xml.min.js"
+		></script>
 		<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 	</head>
 

--- a/src/demo.js
+++ b/src/demo.js
@@ -7,7 +7,8 @@ const fullToolbarOptions = [
   [{ header: [1, 2, 3, false] }],
   ["bold", "italic"],
   ["clean"],
-  ["image"]
+  ["image"],
+  [{ list: 'ordered' }, { list: 'bullet' }]
 ];
 
 console.log("Demo loaded...");

--- a/src/quill.htmlEditButton.js
+++ b/src/quill.htmlEditButton.js
@@ -1,4 +1,4 @@
-import './styles.css';
+import "./styles.css";
 
 function $create(elName) {
   return document.createElement(elName);
@@ -26,7 +26,7 @@ class htmlEditButton {
     debug = options && options.debug;
     Logger.log("logging enabled");
     // Add button to all quill toolbar instances
-    const toolbarModule = quill.getModule('toolbar');
+    const toolbarModule = quill.getModule("toolbar");
     if (!toolbarModule) {
       throw new Error(
         'quill.htmlEditButton requires the "toolbar" module to be included too'
@@ -50,12 +50,12 @@ class htmlEditButton {
   registerDivModule() {
     // To allow divs to be inserted into html editor
     // obtained from issue: https://github.com/quilljs/quill/issues/2040
-    var Block = Quill.import('blots/block');
+    var Block = Quill.import("blots/block");
     class Div extends Block {}
     Div.tagName = "div";
     Div.blotName = "div";
     Div.allowedChildren = Block.allowedChildren;
-    Div.allowedChildren.push(Block)
+    Div.allowedChildren.push(Block);
     Quill.register(Div);
   }
 }
@@ -72,13 +72,15 @@ function launchPopupEditor(quill, options) {
   $setAttr(popupContainer, "class", "ql-html-popupContainer");
   const popupTitle = $create("i");
   $setAttr(popupTitle, "class", "ql-html-popupTitle");
-  popupTitle.innerText = msg
+  popupTitle.innerText = msg;
   const textContainer = $create("div");
   textContainer.appendChild(popupTitle);
   $setAttr(textContainer, "class", "ql-html-textContainer");
-  const textArea = $create("textarea");
-  $setAttr(textArea, "class", "ql-html-textArea");
-  textArea.value = formatHTML(htmlFromEditor);
+  const codeBlock = $create("pre");
+  $setAttr(codeBlock, "data-language", "xml");
+  codeBlock.innerText = formatHTML(htmlFromEditor);
+  const htmlEditor = $create("div");
+  $setAttr(htmlEditor, "class", "ql-html-textArea");
   const buttonCancel = $create("button");
   buttonCancel.innerHTML = cancelText;
   $setAttr(buttonCancel, "class", "ql-html-buttonCancel");
@@ -89,11 +91,15 @@ function launchPopupEditor(quill, options) {
 
   buttonGroup.appendChild(buttonCancel);
   buttonGroup.appendChild(buttonOk);
-  textContainer.appendChild(textArea);
+  htmlEditor.appendChild(codeBlock);
+  textContainer.appendChild(htmlEditor);
   textContainer.appendChild(buttonGroup);
   popupContainer.appendChild(textContainer);
   overlayContainer.appendChild(popupContainer);
   document.body.appendChild(overlayContainer);
+  var editor = new Quill(htmlEditor, {
+    modules: { syntax: options.syntax && Boolean(hljs) },
+  });
 
   buttonCancel.onclick = function() {
     document.body.removeChild(overlayContainer);
@@ -104,7 +110,7 @@ function launchPopupEditor(quill, options) {
     e.stopPropagation();
   };
   buttonOk.onclick = function() {
-    const output = textArea.value.split(/\r?\n/g).map(el => el.trim());
+    const output = editor.container.querySelector(".ql-editor").innerText.split(/\r?\n/g).map(el => el.trim());
     const noNewlines = output.join("");
     quill.container.querySelector(".ql-editor").innerHTML = noNewlines;
     document.body.removeChild(overlayContainer);

--- a/src/quill.htmlEditButton.js
+++ b/src/quill.htmlEditButton.js
@@ -98,7 +98,7 @@ function launchPopupEditor(quill, options) {
   overlayContainer.appendChild(popupContainer);
   document.body.appendChild(overlayContainer);
   var editor = new Quill(htmlEditor, {
-    modules: { syntax: options.syntax && Boolean(hljs) },
+    modules: { syntax: options.syntax },
   });
 
   buttonCancel.onclick = function() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,6 +26,7 @@
 }
 
 .ql-html-textArea {
+  background: #fff;
   position: absolute;
   left: 15px;
   width: calc(100% - 45px);


### PR DESCRIPTION
Adds syntax highlighting via highlight.js since that is what Quill uses.
Syntax highlighting can be enabled via the new `syntax` option by setting it to `true`.
syntax highlighting, when enabled, requires highlight.js be on the `window` as `window.hljs` (just like Quill) or it will throw.
Updated README to add `syntax` to options

BREAKING CHANGE: with this change the `textarea` becomes a `Quill`; always, regardless of whether or not `syntax` is enabled.
Migration: If you have additional custom styles, they may need to be changed to target the quill classes instead of the `textarea`.

Closes #15

Note: I can avoid the breaking change by keeping logic for both the `textarea` and `quill` editor and switching on them based on the new `syntax` option, but it seemed like an undesired complexity. (basically I would need to conditionally add one or the other to the modal and in the save read the value from one or the other (since we access the value differently between the two.)).

Screens:

Quill 1.3.6
![Kapture 2020-08-27 at 14 39 25](https://user-images.githubusercontent.com/664714/91481897-2baf1900-e873-11ea-9441-1f4c97f1d7c7.gif)

Quill 2.0.0-dev.4 (latest at the time of this writing). Since syntax highlighting has changed (it now allows you to pass the language and looks/colors different / better in XML/HTML)
![Kapture 2020-08-27 at 14 39 37](https://user-images.githubusercontent.com/664714/91482051-6add6a00-e873-11ea-8c46-a7a47a439081.gif)

Note: looking back at the gifs I probably should have showed me editing the text/html... but I didn't. Trust me it works.