### PR TITLE
feat(htmlFormat): show the text on a new line

### DIFF
--- a/src/quill.htmlEditButton.js
+++ b/src/quill.htmlEditButton.js
@@ -119,17 +119,20 @@ function formatHTML(code) {
   const whitespace = " ".repeat(2); // Default indenting 4 whitespaces
   let currentIndent = 0;
   const newlineChar = "\n";
+  let prevChar = null;
   let char = null;
   let nextChar = null;
 
   let result = "";
   for (let pos = 0; pos <= code.length; pos++) {
+    prevChar = char;
     char = code.substr(pos, 1);
     nextChar = code.substr(pos + 1, 1);
 
     const isBrTag = code.substr(pos, 4) === "<br>";
     const isOpeningTag = char === "<" && nextChar !== "/" && !isBrTag;
     const isClosingTag = char === "<" && nextChar === "/" && !isBrTag;
+    const isTagEnd = prevChar === ">" && char !== "<" && char !== " " && currentIndent > 0;
     if (isBrTag) {
       // If opening tag, add newline character and indention
       result += newlineChar;
@@ -145,6 +148,9 @@ function formatHTML(code) {
     else if (isClosingTag) {
       // If there're more closing tags than opening
       if (--currentIndent < 0) currentIndent = 0;
+      result += newlineChar + whitespace.repeat(currentIndent);
+    }
+    if(isTagEnd) {
       result += newlineChar + whitespace.repeat(currentIndent);
     }
 


### PR DESCRIPTION
Currently when the HTML is formatted, the words appear on the same line as the tag. Usually it is nested under the tag with more indention
This change moves the words down to appear nested with correct indention.

Note: this was a relatively small change. It would be nice if inline elements (such as `<strong>` and `<em>`) didn't cause a new line, but that would require a larger refactor of the formatting logic. It might be better to just include something like `html-prettify` ([only 428 bytes min+gzip](https://bundlephobia.com/result?p=html-prettify)) or something else (I didn't look too much, that was the first package on npm for HTML formatter)

Before:
```html
<p>Select the 
  <strong>HTML
  </strong> 
  <em>button
  </em> 
  <strong>
    <em>from
    </em>
  </strong> 
  <em>the
  </em> 
  <strong>toolbar
  </strong>
</p>
<p>
</p>
<p>Try editing this sentence!
</p>
```

After:
```html
<p>
  Select the 
  <strong>
    HTML
  </strong> 
  <em>
    button
  </em> 
  <strong>
    <em>
      from
    </em>
  </strong> 
  <em>
    the
  </em> 
  <strong>
    toolbar
  </strong>
</p>
<p>
</p>
<p>
  Try editing this sentence!
</p>
```