### PR TITLE
Allow to set where the overlayContainer is inserted

### DIFF
--- a/src/quill.htmlEditButton.js
+++ b/src/quill.htmlEditButton.js
@@ -88,6 +88,7 @@ function launchPopupEditor(quill, options) {
   buttonOk.innerHTML = okText;
   const buttonGroup = $create("div");
   $setAttr(buttonGroup, "class", "ql-html-buttonGroup");
+  const prependSelector = document.querySelector(options.prependSelector)
 
   buttonGroup.appendChild(buttonCancel);
   buttonGroup.appendChild(buttonOk);
@@ -96,13 +97,24 @@ function launchPopupEditor(quill, options) {
   textContainer.appendChild(buttonGroup);
   popupContainer.appendChild(textContainer);
   overlayContainer.appendChild(popupContainer);
-  document.body.appendChild(overlayContainer);
+
+  if (prependSelector) {
+    prependSelector.prepend(overlayContainer)
+  } else {
+    document.body.appendChild(overlayContainer);
+  }
+
+
   var editor = new Quill(htmlEditor, {
     modules: { syntax: options.syntax },
   });
 
   buttonCancel.onclick = function() {
-    document.body.removeChild(overlayContainer);
+    if (prependSelector) {
+      prependSelector.removeChild(overlayContainer)
+    } else {
+      document.body.removeChild(overlayContainer);
+    }
   };
   overlayContainer.onclick = buttonCancel.onclick;
   popupContainer.onclick = function(e) {
@@ -121,7 +133,12 @@ function launchPopupEditor(quill, options) {
     .replace(/(<[^\/<>]+>)\s(<[^\/<>]+>)/g, "$1$2") // remove space between multiple starting tags
     .trim();
     quill.container.querySelector(".ql-editor").innerHTML = noNewlines;
-    document.body.removeChild(overlayContainer);
+
+    if (prependSelector) {
+      prependSelector.removeChild(overlayContainer)
+    } else {
+      document.body.removeChild(overlayContainer);
+    }
   };
 }
 


### PR DESCRIPTION
Currently I had a problem trying to open the html editor inside a
bootstrap modal. Bootstrap modal uses a display block property that
prevents the HTML editor allow to edit the content. I was able to solve
the problem inserting the overlayContainer before the bootstrap modal.

This adds a new option called prependSelector that allows to select
where you want to insert the overlayContainer.

Co-authored-by: Oscar Zatarain <ozatarain@hotmail.com>