### PR TITLE
Add Webpack sourcemap configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "watch": "webpack --watch --progress",
     "start": "webpack-dev-server --mode development --hot --port 8001",
-    "build": "webpack --mode production"
+    "build": "webpack --mode production",
+    "clean": "rm -rf dist/"
   },
   "keywords": [
     "quill",
@@ -28,6 +29,7 @@
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "highlight.js": "^10.1.2",
     "style-loader": "^0.19.1",
+    "terser-webpack-plugin": "2.3.6",
     "uglifyjs-webpack-plugin": "^1.1.6",
     "webpack": "^4.1.0",
     "webpack-cli": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "watch": "webpack --watch --progress",
-    "start": "webpack-dev-server --mode development --hot --port 8001",
+    "start": "webpack --mode development && webpack-dev-server --mode development --hot --port 8001",
     "build": "webpack --mode production",
     "clean": "rm -rf dist/"
   },

--- a/src/demo-script-tag-2.x.html
+++ b/src/demo-script-tag-2.x.html
@@ -15,6 +15,7 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/styles/github.min.css"
     />
+    <link href="../dist/quill.htmlEditButton.min.css" rel="stylesheet"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/highlight.min.js"></script>
     <script
       charset="UTF-8"

--- a/src/demo-script-tag.html
+++ b/src/demo-script-tag.html
@@ -15,6 +15,7 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/styles/github.min.css"
     />
+    <link href="../dist/quill.htmlEditButton.min.css" rel="stylesheet"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/highlight.min.js"></script>
     <script
       charset="UTF-8"

--- a/src/demo.html
+++ b/src/demo.html
@@ -15,6 +15,7 @@
 			rel="stylesheet"
 			href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/styles/github.min.css"
 		/>
+    <link href="../dist/quill.htmlEditButton.min.css" rel="stylesheet"/>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/highlight.min.js"></script>
 		<script
 			charset="UTF-8"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,8 @@ const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
+const isProd = process.argv.includes('production');
+
 module.exports = [{
   entry: {
     "quill.htmlEditButton": "./src/quill.htmlEditButton.js",
@@ -10,15 +12,16 @@ module.exports = [{
   output: {
     filename: "[name].min.js",
     path: path.resolve(__dirname, "dist"),
+    libraryTarget: "umd",
+    publicPath: "/dist/"
   },
   devServer: {
-    //contentBase: './src',
-    https: true,
+    contentBase: './src'
   },
   externals: {
     quill: "Quill",
   },
-  devtool: 'source-map',
+  devtool: isProd ? 'source-map' : "inline-source-map",
   optimization: {
     minimize: true,
     minimizer: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,41 +1,59 @@
 const path = require("path");
+const TerserPlugin = require("terser-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
-const isProd = process.argv.includes('production');
-
-module.exports = [
-  {
-    entry: {
-      "quill.htmlEditButton": "./src/quill.htmlEditButton.js",
-      demo: "./src/demo.js"
-    },
-    output: {
-      filename: "[name].min.js",
-      path: path.resolve(__dirname, "dist"),
-      libraryTarget: "umd",
-      publicPath: "/dist/"
-    },
-    devServer: {
-      contentBase: "./src"
-    },
-    externals: {
-      quill: "Quill"
-    },
-    devtool: isProd ? undefined : "inline-source-map",
-    module: {
-      rules: [
-        {
-          test: /\.css$/,
-          use: ["style-loader", "css-loader"]
+module.exports = [{
+  entry: {
+    "quill.htmlEditButton": "./src/quill.htmlEditButton.js",
+    demo: "./src/demo.js",
+  },
+  output: {
+    filename: "[name].min.js",
+    path: path.resolve(__dirname, "dist"),
+  },
+  devServer: {
+    //contentBase: './src',
+    https: true,
+  },
+  externals: {
+    quill: "Quill",
+  },
+  devtool: 'source-map',
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        extractComments: true,
+        cache: true,
+        parallel: true,
+        sourceMap: true, // Must be set to true if using source-maps in production
+        terserOptions: {
+          // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
+          extractComments: "all",
+          compress: {
+            drop_console: false,
+          },
         },
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          use: {
-            loader: "babel-loader"
-          }
-        }
-      ]
-    }
-  }
-];
+      }),
+    ],
+  },
+  module: {
+    rules: [{
+      test: /\.css$/,
+      use: ExtractTextPlugin.extract({
+        use: [{
+          loader: "css-loader",
+        }, ],
+      }),
+    },
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+        },
+      },
+    ],
+  },
+  plugins: [new ExtractTextPlugin("quill.htmlEditButton.min.css")],
+}, ];


### PR DESCRIPTION
Currently the webpacker release configuration is generating the
sourcemaps in the same min.js file, This is a problem if you try to
deploy the dependency in some systems, we had a problem deploying the
sourcemaps to sentry, so we updated the configuration to optimize the
file generation and generate the sourcemaps in independent files.

                               Asset       Size  Chunks                   Chunk Names
                         demo.min.js   5.27 KiB       0  [emitted]        demo
                     demo.min.js.map     17 KiB       0  [emitted] [dev]  demo
        quill.htmlEditButton.min.css  818 bytes    0, 1  [emitted]        demo, quill.htmlEditButton
    quill.htmlEditButton.min.css.map  105 bytes    0, 1  [emitted] [dev]  demo, quill.htmlEditButton
         quill.htmlEditButton.min.js   4.92 KiB       1  [emitted]        quill.htmlEditButton
     quill.htmlEditButton.min.js.map   16.1 KiB       1  [emitted] [dev]  quill.htmlEditButton

Co-authored-by: Oscar Zatarain <ozatarain@hotmail.com>