### PR TITLE
Minor HTML tweaks

### DIFF
--- a/src/quill.htmlEditButton.js
+++ b/src/quill.htmlEditButton.js
@@ -70,7 +70,7 @@ function launchPopupEditor(quill, options) {
 
   $setAttr(overlayContainer, "class", "ql-html-overlayContainer");
   $setAttr(popupContainer, "class", "ql-html-popupContainer");
-  const popupTitle = $create("i");
+  const popupTitle = $create("span");
   $setAttr(popupTitle, "class", "ql-html-popupTitle");
   popupTitle.innerText = msg;
   const textContainer = $create("div");
@@ -86,6 +86,7 @@ function launchPopupEditor(quill, options) {
   $setAttr(buttonCancel, "class", "ql-html-buttonCancel");
   const buttonOk = $create("button");
   buttonOk.innerHTML = okText;
+  $setAttr(buttonOk, "class", "ql-html-buttonOk");
   const buttonGroup = $create("div");
   $setAttr(buttonGroup, "class", "ql-html-buttonGroup");
   const prependSelector = document.querySelector(options.prependSelector)

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,6 +40,7 @@
 .ql-html-popupTitle {
   margin: 0;
   display: block;
+  font-style: italic;
 }
 
 .ql-html-buttonGroup {


### PR DESCRIPTION
Currently the buttonOk doesn't have a CSS class for customization and
the popupTitle is an `i` tag that sets the font-style italic by
default. This change adds the ql-html-buttonOk for the buttonOk and
updates the popupTitle to a span class that is decorated with the
font-style italic to keep the current design.

Proof that the change doesn't affect the current design
|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/2718753/98749214-ca321d00-2380-11eb-94d3-6ae36be024a0.png)|![image](https://user-images.githubusercontent.com/2718753/98749234-d4541b80-2380-11eb-9b6b-a128b3d3617d.png)|

Current application:
![image](https://user-images.githubusercontent.com/2718753/98749353-0f564f00-2381-11eb-9034-1a1d8f2fdb3f.png)


Co-authored-by: Juan Zenon <juanjoze0424@gmail.com>