### PR TITLE
Adjust editor container width

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -20,7 +20,6 @@
 
 .ql-html-textContainer {
   position: relative;
-  width: calc(100% - 40px);
   height: calc(100% - 40px);
   padding: 20px;
 }
@@ -29,7 +28,7 @@
   background: #fff;
   position: absolute;
   left: 15px;
-  width: calc(100% - 45px);
+  width: calc(100% - 30px);
   height: calc(100% - 116px);
 }
 


### PR DESCRIPTION
Currently the editor section has a bigger space in the right side. This
updates the CSS width calculations to get a better spacing in both
sides.

|Before|After|
|--|--|
|![Image 2020-11-10 at 6 19 40 PM](https://user-images.githubusercontent.com/2718753/98753413-e71f1e00-2389-11eb-95e4-763beb905a49.png)|![Image 2020-11-10 at 7 11 16 PM](https://user-images.githubusercontent.com/2718753/98753439-f7cf9400-2389-11eb-9bf7-caf06aaa72f9.png)|
|![Image 2020-11-10 at 7 10 44 PM](https://user-images.githubusercontent.com/2718753/98753460-0322bf80-238a-11eb-80f6-bade0cd33a91.png)|![Image 2020-11-10 at 7 17 10 PM](https://user-images.githubusercontent.com/2718753/98753476-0b7afa80-238a-11eb-86ce-2b9916a04cad.png)|
|![Screen Recording 2020-11-10 at 07 18 12 PM](https://user-images.githubusercontent.com/2718753/98753498-17ff5300-238a-11eb-989a-87e904da08c5.gif)|![Screen Recording 2020-11-10 at 07 17 35 PM](https://user-images.githubusercontent.com/2718753/98753508-20f02480-238a-11eb-8c94-b82ab88f11cb.gif)|



