### PR TITLE
correct webpack externals 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = [
       contentBase: "./src",
     },
     externals: {
-      quill: "Quill",
+      quill: "quill",
     },
     devtool: isProd ? "source-map" : "inline-source-map",
     optimization: {


### PR DESCRIPTION
The **q** in **quill** should be lowercase,
If use uppercase **Q**, it can lead to unexpected behavior when compiling.
> https://github.com/benwinding/quill-html-edit-button/issues/36