### PR TITLE
Add new replace to remove space between end and start tags

### DIFF
--- a/src/quill.htmlEditButton.ts
+++ b/src/quill.htmlEditButton.ts
@@ -149,6 +149,7 @@ function launchPopupEditor(
     const noNewlines = output
       .replace(/\s+/g, " ") // convert multiple spaces to a single space. This is how HTML treats them
       .replace(/(<[^\/<>]+>)\s+/g, "$1") // remove spaces after the start of a new tag
+      .replace(/>\s+|\s+</g, m => m.trim()) // remove spaces between starting and ending tags
       .replace(/<\/(p|ol|ul)>\s/g, "</$1>") // remove spaces after the end of lists and paragraphs, they tend to break quill
       .replace(/\s<(p|ol|ul)>/g, "<$1>") // remove spaces before the start of lists and paragraphs, they tend to break quill
       .replace(/<\/li>\s<li>/g, "</li><li>") // remove spaces between list items, they tend to break quill


### PR DESCRIPTION

I had problems when using centralized lists, when I saved this list by the editor, the content was deleted because there were spaces between the starting tags and the ending tags. To solve this I added another replace