### PR TITLE
Set button type

### DIFF
--- a/src/quill.htmlEditButton.ts
+++ b/src/quill.htmlEditButton.ts
@@ -42,6 +42,7 @@ class htmlEditButton {
     const button = $create("button");
     button.innerHTML = options.buttonHTML || "&lt;&gt;";
     button.title = options.buttonTitle || "Show HTML source";
+    button.type = "button";
     button.onclick = function (e) {
       e.preventDefault();
       launchPopupEditor(quill, options);


### PR DESCRIPTION
Add button type 'button' to 'Show HTML source' button to prevent opening the editor on form submit (because the type has a fallback to submit if none exists).