### PR TITLE
Use Logger.log instead of console.log

### DIFF
--- a/src/quill.htmlEditButton.ts
+++ b/src/quill.htmlEditButton.ts
@@ -144,7 +144,7 @@ function launchPopupEditor(
     const qlElement = container.querySelector(".ql-editor") as HTMLDivElement;
     const htmlInputFromPopup = qlElement.innerText;
     const htmlOutputFormatted = OutputHTMLParser(htmlInputFromPopup);
-    console.log('OutputHTMLParser', { htmlInputFromPopup, htmlOutputFormatted })
+    Logger.log('OutputHTMLParser', { htmlInputFromPopup, htmlOutputFormatted })
     saveCallback(htmlOutputFormatted);
     if (prependSelector) {
       prependSelector.removeChild(overlayContainer);


### PR DESCRIPTION
Hello,

Just a small PR to fix a call of `console.log()` instead of `Logger.log()` in `quill.htmlEditButton.ts`, that was a kinda "big" log appearing in console.