### PR TITLE
Common menu and list of demos

### DIFF
--- a/demos/build.sh
+++ b/demos/build.sh
@@ -5,6 +5,8 @@ mkdir dist
 
 # Common Header
 cp ./header-text.js ./dist
+# Demo list
+cp ./demos-index.html ./dist/index.html
 
 # Build typescript
 cd typescript

--- a/demos/build.sh
+++ b/demos/build.sh
@@ -3,6 +3,9 @@
 rm -rf ./dist
 mkdir dist
 
+# Common Header
+cp ./header-text.js ./dist
+
 # Build typescript
 cd typescript
 rm -rf ./dist

--- a/demos/demos-index.html
+++ b/demos/demos-index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>quill-html-edit-button (Demos)</title>
+</head>
+
+<body>
+  <h1 id="-quill-html-edit-button-"><code>quill-html-edit-button</code></h1>
+  <p>This is a <a href="https://github.com/quilljs/quill/">quill.js</a> module which allows you to quickly view/edit the
+    HTML in the editor.</p>
+  <p><img width="600px" style="max-width: 100%;" src="https://user-images.githubusercontent.com/664714/93285035-f7f44e80-f7a1-11ea-83c7-59e151c53c06.gif"
+      alt="Demo"></p>
+  <h2 id="demos">Demos</h2>
+  <p>Below are a few demos for the <a
+      href="https://github.com/benwinding/quill-html-edit-button">quill-html-edit-button</a> library.</p>
+  <ul>
+    <li><a href="./javascript/">Live Demo (webpack javascript)</a></li>
+    <li><a href="./typescript/">Live Demo (webpack typescript)</a></li>
+    <li><a href="./vue/">Live Demo (webpack vue)</a></li>
+    <li><a href="./script-tags/demo-quill-1.x.html">Live Demo (script tags quill-1.x)</a></li>
+    <li><a href="./script-tags/demo-quill-2.x.html">Live Demo (script tags quill-2.x) With Tables!</a></li>
+  </ul>
+
+</body>
+</html>

--- a/demos/header-text.js
+++ b/demos/header-text.js
@@ -25,8 +25,7 @@ const corner = document.createElement('div');
 corner.innerHTML = cornerHTML;
 
 // Add to DOM after first JS frame
-
-setTimeout(() => {
+window.addEventListener('load', function() {
   document.body.prepend(header);
   document.body.prepend(corner);
 })

--- a/demos/header-text.js
+++ b/demos/header-text.js
@@ -1,0 +1,32 @@
+const demoTitle = document.title;
+const demoSourceCodeLink = document.getElementById('src-code').getAttribute('data');
+
+// HEADER TEXT
+const headerHtml = `<div style="width: 100%; display: flex; align-items: center;">
+<a href=".." style="text-decoration: none; color: grey;"><h3>All Demos</h3></a>
+<div style="margin: 0 10px;">></div>
+<h3>${document.title}</h3>
+<a href="${demoSourceCodeLink}" style="flex-grow: 1; text-align: right; color: grey; padding-right: 50px;"><h4>Demo Source Code</h4></a>
+</div>
+`;
+const header = document.createElement('div');
+header.innerHTML = headerHtml;
+
+// GITHUB CORNER
+const cornerHTML = `<a href="${demoSourceCodeLink}" class="github-corner" aria-label="View source on GitHub">
+  <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+    <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+  </svg>
+</a>
+<style>
+  .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>`;
+const corner = document.createElement('div');
+corner.innerHTML = cornerHTML;
+
+// Add to DOM after first JS frame
+
+setTimeout(() => {
+  document.body.prepend(header);
+  document.body.prepend(corner);
+})

--- a/demos/javascript/public/index.html
+++ b/demos/javascript/public/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Quill Demo (javascript)</title>
-    <a href="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/javascript/demo.html" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+    <link id="src-code" data="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/javascript" ></link>
+    <script src="./header-text.js" ></script>
 
     <!-- Theme included stylesheets -->
     <link href="/static/favicon.ico" rel="icon" type="image/x-icon" />
@@ -23,8 +24,7 @@
     ></script>
   </head>
 
-  <body>
-    <h3>Quill Demo (javascript)</h3>
+  <body> 
     <!-- Create the editor container -->
     <div id="editor">
       <p>Select the HTML button from the toolbar</p>

--- a/demos/javascript/webpack.config.js
+++ b/demos/javascript/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     new WriteFilePlugin(),
     new CopyWebpackPlugin([
       { from: 'public', to: '.' },
+      { from: '../header-text.js', to: '.' },
     ]),
   ],
   devtool: isProd ? "source-map" : "inline-source-map",

--- a/demos/script-tags/demo-quill-1.x.html
+++ b/demos/script-tags/demo-quill-1.x.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Quill Demo (script tag) Quill 1.x</title>
-    <a href="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/script-tags/demo-quill-1.x.html" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+    <link id="src-code" data="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/script-tags/demo-quill-1.x.html" ></link>
+    <script src="../header-text.js" ></script>
 
     <!-- Theme included stylesheets -->
     <link href="/static/favicon.ico" rel="icon" type="image/x-icon" />
@@ -25,7 +26,6 @@
   </head>
 
   <body>
-    <h3>Quill Demo (script tag) Quill 1.x</h3>
     <!-- Create the editor container -->
     <div id="editor">
       <p>Select the HTML button from the toolbar</p>

--- a/demos/script-tags/demo-quill-2.x.html
+++ b/demos/script-tags/demo-quill-2.x.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Quill Demo (script tag) Quill 2.x</title>
-    <a href="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/script-tags/demo-quill-2.x.html" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+    <link id="src-code" data="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/script-tags/demo-quill-2.x.html" ></link>
+    <script src="../header-text.js" ></script>
 
     <!-- Theme included stylesheets -->
     <link href="/static/favicon.ico" rel="icon" type="image/x-icon" />
@@ -25,7 +26,6 @@
   </head>
 
   <body>
-    <h3>Quill Demo (script tag) Quill 2.x</h3>
     <!-- Create the editor container -->
     <div id="editor">
       <p>Select the HTML button from the toolbar</p>

--- a/demos/typescript/public/index.html
+++ b/demos/typescript/public/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Quill Demo (typescript)</title>
-    <a href="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/typescript/demo.html" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+    <link id="src-code" data="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/typescript" ></link>
+    <script src="./header-text.js" ></script>
 
     <!-- Theme included stylesheets -->
     <link href="/static/favicon.ico" rel="icon" type="image/x-icon" />
@@ -24,7 +25,6 @@
   </head>
 
   <body>
-    <h3>Quill Demo (typescript)</h3>
     <!-- Create the editor container -->
     <div id="editor">
       <p>Select the HTML button from the toolbar</p>

--- a/demos/typescript/public/index.html
+++ b/demos/typescript/public/index.html
@@ -36,6 +36,6 @@
       src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise"
       crossorigin="anonymous"
     ></script>
-    <script src="../index.min.js"></script>
+    <script src="./index.min.js"></script>
   </body>
 </html>

--- a/demos/typescript/webpack.config.js
+++ b/demos/typescript/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     new WriteFilePlugin(),
     new CopyWebpackPlugin([
       { from: 'public', to: '.' },
+      { from: '../header-text.js', to: '.' },
     ]),
   ],
   devtool: isProd ? "source-map" : "inline-source-map",

--- a/demos/vue/public/index.html
+++ b/demos/vue/public/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Quill Demo (vue)</title>
-    <a href="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/vue/demo.html" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+    <link id="src-code" data="https://github.com/benwinding/quill-html-edit-button/blob/master/src/demos/vue" ></link>
+    <script src="./header-text.js" ></script>
 
     <!-- Theme included stylesheets -->
     <link href="/static/favicon.ico" rel="icon" type="image/x-icon" />
   </head>
 
   <body>
-    <h3>Quill Demo (vue)</h3>
     <!-- Create the editor container -->
     <div id="app"></div>
 

--- a/demos/vue/webpack.config.js
+++ b/demos/vue/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
     new WriteFilePlugin(),
     new CopyWebpackPlugin([
       { from: 'public', to: '.' },
+      { from: '../header-text.js', to: '.' },
     ]),
     new VueLoaderPlugin(),
   ],


### PR DESCRIPTION
- Adds a common script `header-text.js` called for all demos (adds header dynamically)
- Adds demo list page to easily navigate between demos