### PR TITLE
Cannot find module 'options' in Angular and htmlEditButton reference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import { QuillHtmlEditButtonOptions } from "./options";
+import {htmlEditButton} from "./quill.htmlEditButton";
 
-export { QuillHtmlEditButtonOptions }
+export { QuillHtmlEditButtonOptions };
+export { htmlEditButton };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import { QuillHtmlEditButtonOptions } from "options";
+import { QuillHtmlEditButtonOptions } from "./options";
 
 export { QuillHtmlEditButtonOptions }


### PR DESCRIPTION
Fix error in angular:

Error: node_modules/quill-html-edit-button/types/index.d.ts:1:44 - error TS2307: Cannot find module 'options' or its corresponding type declarations.

1 import { QuillHtmlEditButtonOptions } from "options";