### PR TITLE
Fix webpack versions prepare for upgrade

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -9,10 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Use Node.js 12.22
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
-          node-version: 12.22
+          node-version: 14.21.3
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.14.2
+          node-version: 14.21.3
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v1

--- a/demos/javascript/package.json
+++ b/demos/javascript/package.json
@@ -9,8 +9,9 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@webpack-cli/serve": "^1.6.1",
-    "webpack-cli": "4.x",
-    "webpack": "4.x"
+    "@webpack-cli/serve": "1.7.0",
+    "webpack-dev-server": "4.7.4",
+    "webpack-cli": "4.10.0",
+    "webpack": "4.44.1"
   }
 }

--- a/demos/javascript/package.json
+++ b/demos/javascript/package.json
@@ -9,9 +9,9 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@webpack-cli/serve": "1.7.0",
-    "webpack-dev-server": "4.7.4",
+    "terser-webpack-plugin": "1.4.5",
+    "webpack": "5.89.0",
     "webpack-cli": "4.10.0",
-    "webpack": "4.44.1"
+    "webpack-dev-server": "4.15.1"
   }
 }

--- a/demos/javascript/webpack.config.js
+++ b/demos/javascript/webpack.config.js
@@ -17,6 +17,9 @@ module.exports = {
   },
   devServer: {
     port: 8001,
+    static: {
+      directory: path.resolve(__dirname, "dist"),
+    }
   },
   plugins: [
     new WriteFilePlugin(),

--- a/demos/javascript/webpack.config.js
+++ b/demos/javascript/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const WriteFilePlugin = require('write-file-webpack-plugin');
 
 const isProd = process.argv.includes("production");
 
@@ -19,10 +18,12 @@ module.exports = {
     port: 8001,
     static: {
       directory: path.resolve(__dirname, "dist"),
-    }
+    },
+    devMiddleware: {
+      writeToDisk: true,
+    },
   },
   plugins: [
-    new WriteFilePlugin(),
     new CopyWebpackPlugin([
       { from: 'public', to: '.' },
       { from: '../header-text.js', to: '.' },

--- a/demos/typescript/package.json
+++ b/demos/typescript/package.json
@@ -9,8 +9,9 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@webpack-cli/serve": "^1.6.1",
-    "webpack-cli": "4.x",
-    "webpack": "4.x"
+    "terser-webpack-plugin": "1.4.5",
+    "webpack": "5.89.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.15.1"
   }
 }

--- a/demos/typescript/webpack.config.js
+++ b/demos/typescript/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const WriteFilePlugin = require('write-file-webpack-plugin');
 
 const isProd = process.argv.includes("production");
 
@@ -13,13 +12,15 @@ module.exports = {
     filename: "[name].min.js",
     libraryTarget: "umd",
     path: path.resolve(__dirname, "dist"),
-    publicPath: "/dist",
   },
   devServer: {
     port: 8001,
+    hot: true,
+    devMiddleware: {
+      writeToDisk: true,
+    },
   },
   plugins: [
-    new WriteFilePlugin(),
     new CopyWebpackPlugin([
       { from: 'public', to: '.' },
       { from: '../header-text.js', to: '.' },

--- a/demos/vue/package.json
+++ b/demos/vue/package.json
@@ -9,12 +9,12 @@
     "build": "webpack --mode production"
   },
   "devDependencies": {
-    "@vueup/vue-quill": "^1.0.0-beta.8",
-    "@webpack-cli/serve": "^1.6.1",
-    "vue": "^3.2.31",
-    "vue-loader": "^17.0.0",
-    "vue-template-compiler": "^2.6.14",
-    "webpack": "5.x",
-    "webpack-cli": "4.x"
+    "@vueup/vue-quill": "1.0.0-beta.8",
+    "vue": "3.3.7",
+    "vue-loader": "17.3.1",
+    "vue-template-compiler": "2.6.14",
+    "webpack": "5.89.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.15.1"
   }
 }

--- a/demos/vue/webpack.config.js
+++ b/demos/vue/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const WriteFilePlugin = require('write-file-webpack-plugin');
 const { VueLoaderPlugin } = require('vue-loader');
 
 const isProd = process.argv.includes("production");
@@ -14,13 +13,15 @@ module.exports = {
     filename: "[name].min.js",
     libraryTarget: "umd",
     path: path.resolve(__dirname, "dist"),
-    publicPath: "/dist",
   },
   devServer: {
     port: 8001,
+    hot: true,
+    devMiddleware: {
+      writeToDisk: true,
+    },
   },
   plugins: [
-    new WriteFilePlugin(),
     new CopyWebpackPlugin([
       { from: 'public', to: '.' },
       { from: '../header-text.js', to: '.' },
@@ -70,6 +71,7 @@ module.exports = {
       },
       {
         test: /\.vue$/,
+        exclude: /node_modules/,
         loader: 'vue-loader'
       },
     ],

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.11",
     "typescript": "^4.1.2",
-    "uglifyjs-webpack-plugin": "^1.1.6",
     "webpack": "^4.1.0",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "uglifyjs-webpack-plugin": "^1.1.6",
     "webpack": "^4.1.0",
     "webpack-cli": "^3.2.1",
-    "webpack-dev-server": "^3.1.14",
-    "write-file-webpack-plugin": "^4.5.1"
+    "webpack-dev-server": "^3.1.14"
   }
 }


### PR DESCRIPTION
- Fixes `package.json` versions in demo directories (dependency hell 💀)
- Upgrading in future, just locking them to ensure they work
- Seems to be an issue with newer versions of node (> node@14) getting [this issue](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported)