### PR TITLE
feat: emit text-change event when saving back to quill

### DIFF
--- a/src/quill.htmlEditButton.ts
+++ b/src/quill.htmlEditButton.ts
@@ -36,8 +36,10 @@ class htmlEditButton {
     button.innerHTML = options.buttonHTML || "&lt;&gt;";
     button.title = options.buttonTitle || "Show HTML source";
     button.type = "button";
+    const originalHtml = quill.root.innerHTML;
     const onSave = (html: string) => {
       quill.clipboard.dangerouslyPasteHTML(html);
+      quill.emitter.emit('text-change', html, originalHtml, 'user');
     };
     button.onclick = function (e) {
       e.preventDefault();


### PR DESCRIPTION
The `dangerouslyPasteHTML` command unfortunately doesn't trigger the `text-change` event in quill. 
This means anything watching the `text-change` event doesn't get any events from the html editor populating it's content. 
For our use-case we have an angular form field implementation and found that if users were pasting in the html and not making any changes afterwards then that change would be lost. 

This is a simple addition that calls the `text-change` event with the new html content so anything watching for that event gets the new content and can update accordingly. 